### PR TITLE
images: build and publish F35

### DIFF
--- a/.github/workflows/fedora-35.yml
+++ b/.github/workflows/fedora-35.yml
@@ -1,0 +1,58 @@
+name: Fedora 35
+on:
+  repository_dispatch:
+    types:
+    - 'fedora-35'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+
+    - name: Install Dependencies
+      run: |
+        set -ex ;\
+        sudo apt-get update -y ;\
+        sudo apt-get install -y libguestfs-tools ;\
+        echo;
+
+    - name: Code Checkout
+      uses: actions/checkout@v2.3.5
+
+    - name: Prepare Fedora 35 Image
+      run: |
+        set -ex ;\
+        curl --output /tmp/fedora.qcow2 -L "https://mirror.arizona.edu/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2" ;\
+        qemu-img resize /tmp/fedora.qcow2 +16G ;\
+        sudo virt-sysprep -a /tmp/fedora.qcow2 --password fedora:password:fedora ;\
+        sudo virt-customize -a /tmp/fedora.qcow2 --install 'tmux,git,vim,net-tools,qemu-guest-agent' ;\
+        sudo virt-customize -a /tmp/fedora.qcow2 --run-command 'systemctl enable qemu-guest-agent' ;\
+        sudo virt-customize -a /tmp/fedora.qcow2 --run-command "dnf clean all && rm -rf /var/cache/dnf" ;\
+        sudo virt-sysprep -a /tmp/fedora.qcow2 --enable net-hostname,net-hwaddr,machine-id,dhcp-server-state,dhcp-client-state,yum-uuid,udev-persistent-net,tmp-files,smolt-uuid,rpm-db,package-manager-cache
+        echo;
+
+    - name: Build Fedora Cradle
+      run: |
+        PATH=${PATH}:$(pwd) \
+        cradle --image-name quay.io/containercraft/fedora --image-tag 35 --image-file /tmp/fedora.qcow2 ;\
+        echo;
+
+    - name: Login Quay.io
+      uses: docker/login-action@v1.10.0
+      with:
+        logout: false
+        registry: quay.io
+        username: ${{ secrets.ROBOT_USER_QUAY }}
+        password: ${{ secrets.ROBOT_TOKEN_QUAY }}
+
+    - name: Push Fedora Cradle
+      run: |
+        set -ex ;\
+        podman push quay.io/containercraft/fedora:35 ;\
+        podman push quay.io/containercraft/fedora:35 docker://quay.io/containercraft/fedora:latest ;\
+        podman image prune --all --force ;\
+        echo;
+
+    - name: Cleanup
+      run: |
+        rm -rf /tmp/cradle /tmp/*qcow*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,3 +91,12 @@ jobs:
         token: ${{ secrets.GH_ACTIONS_TOKEN }}
         repository: ${{ github.repository }}
         client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+
+    - name: Build Fedora 35
+      if: success()
+      uses: peter-evans/repository-dispatch@v1.1.3
+      with:
+        event-type: fedora-35
+        token: ${{ secrets.GH_ACTIONS_TOKEN }}
+        repository: ${{ github.repository }}
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Duplicated the F34 workflow

tested this locally and published to `ghcr.io/jbpratt/fedora:35`

```
[  159.669771] cloud-init[871]: Complete!
[  160.572893] cloud-init[871]:            /:-------------:\          root@fedora-br0
[  160.576404] cloud-init[871]:         :-------------------::        OS: Fedora
[  160.579691] cloud-init[871]:       :-----------/shhOHbmp---:\      Kernel: x86_64 Linux 5.14.10-300.fc35.x86_64
[  160.582225] cloud-init[871]:     /-----------omMMMNNNMMD  ---:     Uptime: 2m
[  160.585715] cloud-init[871]:    :-----------sMMMMNMNMP.    ---:    Packages: 471
[  160.588181] cloud-init[871]:   :-----------:MMMdP-------    ---\   Shell: sh
[  160.590878] cloud-init[871]:  ,------------:MMMd--------    ---:   Disk: 1.9G / 42G (5%)
[  160.595003] cloud-init[871]:  :------------:MMMd-------    .---:   CPU: Intel Core i5-4690K @ 2x 3.499GHz
[  160.597158] cloud-init[871]:  :----    oNMMMMMMMMMNho     .----:   RAM: 292MiB / 869MiB
[  160.600491] cloud-init[871]:  :--     .+shhhMMMmhhy++   .------/
[  160.602484] cloud-init[871]:  :-    -------:MMMd--------------:
[  160.605632] cloud-init[871]:  :-   --------/MMMd-------------;
[  160.608149] cloud-init[871]:  :-    ------/hMMMy------------:
[  160.610426] cloud-init[871]:  :-- :dMNdhhdNMMNo------------;
[  160.613437] cloud-init[871]:  :---:sdNMMMMNds:------------:
[  160.615597] cloud-init[871]:  :------:://:-------------::
[  160.618573] cloud-init[871]:  :---------------------://
[  160.621911] cloud-init[871]:
[  160.628018] cloud-init[871]: ci-info: no authorized SSH keys fingerprints found for user kc2user.
ci-info: no authorized SSH keys fingerprints found for user kc2user.
```

One thing I'm not sure on is the two Fedora images (34, 35) will be fighting
over the `latest` tag, should I remove that publish step from this workflow or
update 34 to no longer push to latest?
