### PR TITLE
Draft: swap to buildah to build the cradle image

### DIFF
--- a/cradle
+++ b/cradle
@@ -2,153 +2,127 @@
 # ./cradle --image-name registry.com/namespace/rhel --image-tag 8.2 --cradle-image scratch --image-file ./images/rhel-8.2.x86_64.qcow2
 
 import os
-import sys
 import gzip
 import shutil
-import pathlib
 import tempfile
 import argparse
 import subprocess
 import urllib.request
-from datetime import datetime
 
 # Define Mandatory & Optional CLI Flags
 parser = argparse.ArgumentParser(
-    description='KubeVirt Image Cradle Builder to generate OpenShift Virtualization compatible qcow2 import images')
+    description="KubeVirt Image Cradle Builder to generate OpenShift Virtualization compatible qcow2 import images"
+)
 parser.add_argument(
     "--image-name",
     default="localhost/cradle",
     help="Name of cradle image",
     metavar="registry.com/namespace/image-name",
-    required=False)
+    required=False,
+)
 parser.add_argument(
     "--image-tag",
     default="latest",
     help="Image tag",
     metavar="IMAGE_TAG",
-    required=False)
-parser.add_argument(
-    "--build-path",
-    default=("/tmp/cradle"),
-    help="Container build context global path",
-    required=False)
+    required=True,
+)
 parser.add_argument(
     "--cradle-image",
     help="Name of cradle image",
     default="registry.access.redhat.com/ubi8/ubi",
-    required=False)
+    required=False,
+)
 
 
-group = parser.add_mutually_exclusive_group(
-    required=True)
+group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument(
     "--image-archive-url",
     help="qcow image url",
     metavar="https://FQDN/URI/image.qcow2.gz",
     default="",
-    required=False)
+    required=False,
+)
 group.add_argument(
     "--image-url",
     help="qcow image url",
     metavar="https://FQDN/URI/image.qcow2.gz",
     default="",
-    required=False)
+    required=False,
+)
 group.add_argument(
     "--image-file",
     help="qcow image path",
     metavar="/global/path/to/image.qcow2",
     default="",
-    required=False)
-
-
-# Parse cli arguments
-args                     = parser.parse_args()
-
-
-# Base Variables
-rundate                  = datetime.now()
-datetimestr              = rundate.strftime("%Y%m%d%H%M%S")
-cradle_name              = args.image_name
-cradle_tag               = args.image_tag
-build_path               = args.build_path
-container_context        = (args.build_path + "/" + datetimestr)
-qcow2_staging_path       = (container_context + "/rootfs/disk/image.qcow2")
-docker_file              = ("FROM " + args.cradle_image + "\n" + "ADD " + "./rootfs /")
-container_build_cmd      = "podman build"
-
-
-# Create temp cradle build directory tree
-def StageBuildTree(args, container_context):
-    try:
-        os.makedirs(container_context + "/rootfs/disk", exist_ok=True)
-    except OSError:
-        print ("Failed to create container context directory: %container_context " % container_context)
-    else:
-        print( ">> Created Build Context: " + container_context )
-    f = open(container_context + '/Dockerfile', 'w')
-    f.write(docker_file)
-    f.close()
-
-
-# Stage Qcow2 Image File
-def StageImageFile(args, container_context):
-    print( ">> Staging Image File: " + args.image_file )
-    shutil.copy(args.image_file, qcow2_staging_path)
+    required=False,
+)
 
 
 # Download Image from URL
-def DownloadImageFile(args, qcow2_staging_path):
-    download_url = (args.image_url)
-    print( ">> Downloading Image: " + args.image_url )
+def download_image_file(image_url: str, destination: str):
+    print(">> Downloading Image: " + image_url)
     try:
-        with urllib.request.urlopen(download_url) as image_file:
-            with open(qcow2_staging_path, 'wb') as image:
-                image.write(image_file)
-                return 0
-    except Exception as e:
-        print(e)
-        return 1
+        with urllib.request.urlopen(image_url) as image_file:
+            with open(destination, "wb") as image:
+                shutil.copyfileobj(image_file, image)
+    except Exception:
+        raise
 
 
 # Download Image Archive from URL
-def DownloadImageFileArchive(args, qcow2_staging_path):
-    download_url = (args.image_archive_url)
-    print( ">> Downloading Image Archive: " + args.image_archive_url )
+def download_image_file_archive(image_archive_url: str, destination: str):
+    print(f">> Downloading Image Archive: {image_archive_url}")
     try:
-        with urllib.request.urlopen(download_url) as image_gzip:
+        with urllib.request.urlopen(image_archive_url) as image_gzip:
             with gzip.GzipFile(fileobj=image_gzip) as archive:
-                archive_content = archive.read()
-            with open(qcow2_staging_path, 'wb') as image:
-                image.write(archive_content)
-                return 0
-    except Exception as e:
-        print(e)
-        return 1
+                with open(destination, "wb") as image:
+                    shutil.copyfileobj(archive, image)
+    except Exception:
+        raise
 
 
 # Build Disk Image Cradle Container
-def PodmanBuildCradle(container_build_cmd, cradle_name, cradle_tag, container_context):
-    dockerfile = (container_context + "/Dockerfile")
-    build_cmd  = (container_build_cmd + " -f " + dockerfile + " -t " + cradle_name + ":" + cradle_tag + " " + container_context)
-    os.chdir(container_context)
-    print(">> Executing build: \n>>     " + build_cmd)
-    subprocess.run( build_cmd,
-        env=dict(os.environ, STORAGE_DRIVER="overlay"),
-        shell=True, check=True, cwd=container_context
-    )
+def build_cradle(from_image: str, name: str, tag: str, tmpdir: str):
+    def buildah(*cmd) -> str:
+        run_cmd = ["buildah", *cmd]
+        str_cmd = " ".join(run_cmd).replace("\n", "")
+        print(f">>    {str_cmd}")
+        return subprocess.run(
+            run_cmd,
+            env=dict(os.environ, STORAGE_DRIVER="overlay"),
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+        ).stdout
+
+    print(f">> Building Container Disk Image: {name}:{tag}")
+    tmp_image = buildah("from", from_image)
+    buildah("copy", tmp_image, "./rootfs", "/")
+    buildah("commit", tmp_image, name)
+    buildah("tag", name, f"{name}:{tag}")
 
 
-def main():
-    print( ">> Automated KubeVirt Qcow2 Image Cradle Container Builder" )
-    StageBuildTree(args, container_context)
-    if args.image_url != "":
-      DownloadImageFile(args, qcow2_staging_path)
-    if args.image_archive_url != "":
-      DownloadImageFileArchive(args, qcow2_staging_path)
-    if args.image_file != "":
-      StageImageFile(args, qcow2_staging_path)
-    PodmanBuildCradle(container_build_cmd, cradle_name, cradle_tag, container_context)
+def main() -> int:
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="cradle") as tmpdir:
+        staging_dir = tmpdir + "/rootfs/disk"
+        qcow2_staging_path = staging_dir + "/image.qcow2"
+
+        os.makedirs(staging_dir)
+        if args.image_url != "":
+            download_image_file(args.image_url, qcow2_staging_path)
+        elif args.image_archive_url != "":
+            download_image_file_archive(args.image_archive_url, qcow2_staging_path)
+        elif args.image_file != "":
+            print(">> Staging Image File: " + args.image_file)
+            shutil.copy(args.image_file, qcow2_staging_path)
+
+        build_cradle(args.cradle_image, args.image_name, args.image_tag, tmpdir)
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    exit(main())


### PR DESCRIPTION
refactor to use buildah over writing a temporary Dockerfile out

```
❯ ./cradle --image-name ghcr.io/jbpratt/qubo/fedora --image-tag 34-x84_64 --image-file fedora.qcow2
>> Staging Image File: fedora.qcow2
>> Building Container Disk Image: ghcr.io/jbpratt/qubo/fedora:34-x84_64
>>      buildah from registry.access.redhat.com/ubi8/ubi
>>      buildah copy ubi-working-container-7 ./rootfs /
>>      buildah commit ubi-working-container-7 ghcr.io/jbpratt/qubo/fedora
>>      buildah tag ghcr.io/jbpratt/qubo/fedora ghcr.io/jbpratt/qubo/fedora:34-x84_64
```

```
❯ ./cradle --image-name ghcr.io/jbpratt/qubo/fedora --image-tag 34-x84_64 --image-url https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2
>> Downloading Image: https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2
>> Building Container Disk Image: ghcr.io/jbpratt/qubo/fedora:34-x84_64
>>    buildah from registry.access.redhat.com/ubi8/ubi
>>    buildah copy ubi-working-container-8 ./rootfs /
>>    buildah commit ubi-working-container-8 ghcr.io/jbpratt/qubo/fedora
>>    buildah tag ghcr.io/jbpratt/qubo/fedora ghcr.io/jbpratt/qubo/fedora:34-x84_64
```